### PR TITLE
Add macro for getting tables by suffix

### DIFF
--- a/macros/sql/get_tables_by_suffix.sql
+++ b/macros/sql/get_tables_by_suffix.sql
@@ -1,0 +1,23 @@
+{% macro get_tables_by_suffix(schema, suffix, exclude='') %}
+
+    {%- call statement('tables', fetch_result=True) %}
+
+        select
+            distinct table_schema || '.' || table_name as ref
+        from information_schema.tables
+        where table_schema = '{{ schema }}'
+        and table_name ilike '%{{ suffix }}'
+        and table_name not ilike '{{ exclude }}'
+
+    {%- endcall -%}
+
+    {%- set table_list = load_result('tables') -%}
+
+    {%- if table_list and table_list['data'] -%}
+        {%- set tables = table_list['data'] | map(attribute=0) | list %}
+        {{ return(tables) }}
+    {%- else -%}
+        {{ return([]) }}
+    {%- endif -%}
+
+{% endmacro %}


### PR DESCRIPTION
Similar to the existing dbt macro for `get_tables_by_prefix`, this will get all tables by the suffix which is useful for polymorphic programmatic joins especially in `dbt_utils.union_tables`