### PR TITLE
Add option to cast `convert_tz` macro result as a specific type

### DIFF
--- a/macros/shortcuts.sql
+++ b/macros/shortcuts.sql
@@ -1,3 +1,3 @@
-{%- macro convert_tz (column_name, tz='{{var("timezone")}}', tz_alias='{{var("timezone_alias")}}') -%}
+{%- macro convert_tz (column_name, tz=var("timezone"), tz_alias=var("timezone_alias")) -%}
 	convert_timezone('{{tz}}', {{column_name}}) as {{column_name[(column_name.find('.')+1):] + '_' + tz_alias.lower()}}
 {%- endmacro -%}

--- a/macros/shortcuts.sql
+++ b/macros/shortcuts.sql
@@ -1,3 +1,13 @@
-{%- macro convert_tz (column_name, tz=var("timezone"), tz_alias=var("timezone_alias")) -%}
-	convert_timezone('{{tz}}', {{column_name}}) as {{column_name[(column_name.find('.')+1):] + '_' + tz_alias.lower()}}
+{%- macro convert_tz (column_name, tz=var("timezone"), tz_alias=var("timezone_alias"), cast=var('convert_tz_cast', none)) -%}
+	{%- set expression -%}
+		convert_timezone('{{tz}}', {{column_name}})
+	{%- endset -%}
+
+	{%- if cast -%}
+		{%- set expression -%}
+			cast({{expression}} as {{cast}})
+		{%- endset -%}
+	{%- endif -%}
+
+	{{expression}} as {{column_name[(column_name.find('.')+1):] + '_' + tz_alias.lower()}}
 {%- endmacro -%}


### PR DESCRIPTION
If a `convert_tz_cast` var is set to a type then the result of the `convert_tz` macro will automatically be cast as that type.

The `convert_tz` macro is also now compatible with dbt 0.15.