### PR TITLE
Update dbt_project.yml config version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,6 @@
 name: 'utilities'
 version: '0.1'
+config-version: 2
 
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]


### PR DESCRIPTION
In order to be compatible with dbt 0.19+. `dbt deps` fail if this is not present.